### PR TITLE
AB test를 위한 새로운 컨테이너 추가

### DIFF
--- a/docker-related/docker-compose.yml
+++ b/docker-related/docker-compose.yml
@@ -159,44 +159,44 @@ services:
   # ############################################
   # NginX 테스트 상황 시각화를 위한 Gafana, Loki, Promtail
   # ############################################    
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - "3000:3000"
-    networks:
-      - webui_network
-    volumes:
-      - grafana_data:/var/lib/grafana
-    depends_on:
-      - prometheus
-    restart: unless-stopped
+  # grafana:
+  #   image: grafana/grafana:latest
+  #   container_name: grafana
+  #   ports:
+  #     - "3000:3000"
+  #   networks:
+  #     - webui_network
+  #   volumes:
+  #     - grafana_data:/var/lib/grafana
+  #   depends_on:
+  #     - prometheus
+  #   restart: unless-stopped
 
-  loki:
-    image: grafana/loki:2.9.2
-    container_name: loki
-    ports:
-      - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
-    networks:
-      - webui_network
+  # loki:
+  #   image: grafana/loki:2.9.2
+  #   container_name: loki
+  #   ports:
+  #     - "3100:3100"
+  #   command: -config.file=/etc/loki/local-config.yaml
+  #   networks:
+  #     - webui_network
 
-  promtail:
-    image: grafana/promtail:2.9.2 # 또는 다른 버전 유지
-    container_name: promtail
-    volumes:
-      # Nginx 로그 볼륨을 Promtail 컨테이너의 동일 경로에 마운트 (읽기 전용 권장)
-      - nginx_logs:/var/log/nginx:ro # Nginx와 같은 볼륨을 마운트
-      # Promtail 설정을 마운트합니다.
-      - ./promtail-config.yml:/etc/promtail/config.yml
-      # Docker 소켓 마운트는 이 방식에서는 필요 없습니다. (주석 처리하거나 삭제)
-      # - /var/run/docker.sock:/var/run/docker.sock
-    command: -config.file=/etc/promtail/config.yml
-    networks:
-      - webui_network
-    depends_on:
-      - loki
-      - nginx_proxy # Nginx가 로그를 기록한 후에 Promtail이 시작되도록 의존성 추가 (선택 사항이지만 안전함)
+  # promtail:
+  #   image: grafana/promtail:2.9.2 # 또는 다른 버전 유지
+  #   container_name: promtail
+  #   volumes:
+  #     # Nginx 로그 볼륨을 Promtail 컨테이너의 동일 경로에 마운트 (읽기 전용 권장)
+  #     - nginx_logs:/var/log/nginx:ro # Nginx와 같은 볼륨을 마운트
+  #     # Promtail 설정을 마운트합니다.
+  #     - ./promtail-config.yml:/etc/promtail/config.yml
+  #     # Docker 소켓 마운트는 이 방식에서는 필요 없습니다. (주석 처리하거나 삭제)
+  #     # - /var/run/docker.sock:/var/run/docker.sock
+  #   command: -config.file=/etc/promtail/config.yml
+  #   networks:
+  #     - webui_network
+  #   depends_on:
+  #     - loki
+  #     - nginx_proxy # Nginx가 로그를 기록한 후에 Promtail이 시작되도록 의존성 추가 (선택 사항이지만 안전함)
 
 networks:
   webui_network:
@@ -207,7 +207,7 @@ volumes:
   open_webui_v1_data: # OpenWebUI V1 데이터를 영속적으로 저장할 명명된 볼륨 (새로 추가)
   open_webui_v2_data: # OpenWebUI V2 데이터를 영속적으로 저장할 명명된 볼륨 (새로 추가)
   prometheus_data: # Prometheus 데이터 볼륨
-  grafana_data:
-  nginx_logs: # <-- Nginx 로그를 위한 새로운 볼륨 정의
+  # grafana_data:
+  # nginx_logs: # <-- Nginx 로그를 위한 새로운 볼륨 정의
 
   # litellm_data: # LiteLLM 데이터용 볼륨 (필요시 주석 해제)

--- a/docker-related/docker-compose.yml
+++ b/docker-related/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       - "8080:80" # 호스트의 8080 포트를 Nginx 컨테이너의 80 포트로 매핑
     volumes:
       # 사용자 정의 Nginx 설정 파일을 컨테이너 내부에 마운트합니다.
-      # A/B 테스트 라우팅 로직이 여기에 정의됩니다.
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro # 로컬 ./nginx/nginx.conf 파일을 컨테이너 내부로 읽기 전용 마운트
-      # A/B 테스트 로직에 쿠키 등이 필요하면 Nginx 설정에 따라 추가 설정 필요
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # Nginx 로그를 호스트의 명명된 볼륨에 기록하도록 설정 (Promtail이 읽을 수 있도록)
+      - nginx_logs:/var/log/nginx # 이 부분이 이미 활성화되어 있는지 확인 또는 활성화
     depends_on:
       # Nginx는 OpenWebUI V1/V2 서비스가 준비된 후에 시작되어야 합니다.
       - open-webui_v1
@@ -182,17 +182,21 @@ services:
       - webui_network
 
   promtail:
-    image: grafana/promtail:2.9.2
+    image: grafana/promtail:2.9.2 # 또는 다른 버전 유지
     container_name: promtail
     volumes:
-      # Nginx 로그 볼륨을 Promtail 컨테이너의 동일 경로에 마운트
-      - nginx_logs:/var/log/nginx
+      # Nginx 로그 볼륨을 Promtail 컨테이너의 동일 경로에 마운트 (읽기 전용 권장)
+      - nginx_logs:/var/log/nginx:ro # Nginx와 같은 볼륨을 마운트
+      # Promtail 설정을 마운트합니다.
       - ./promtail-config.yml:/etc/promtail/config.yml
+      # Docker 소켓 마운트는 이 방식에서는 필요 없습니다. (주석 처리하거나 삭제)
+      # - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.yml
     networks:
       - webui_network
     depends_on:
-      - loki # Promtail은 Loki가 시작된 후 시작되어야 함
+      - loki
+      - nginx_proxy # Nginx가 로그를 기록한 후에 Promtail이 시작되도록 의존성 추가 (선택 사항이지만 안전함)
 
 networks:
   webui_network:

--- a/docker-related/docker-compose.yml
+++ b/docker-related/docker-compose.yml
@@ -1,14 +1,89 @@
-version: '3.8'
 
 services:
-  ############################################
-  # LiteLLM - LLM Proxy
-  ############################################
+  # --- Reverse Proxy Service (Nginx for A/B Testing) ---
+  nginx_proxy:
+    image: nginx:latest # Nginx 이미지 사용
+    container_name: nginx_ab_router # 컨테이너 이름 변경
+    # 사용자가 외부에서 접근할 포트를 Nginx로 매핑합니다.
+    # 기존 OpenWebUI 포트(8080)를 Nginx로 연결합니다.
+    ports:
+      - "8080:80" # 호스트의 8080 포트를 Nginx 컨테이너의 80 포트로 매핑
+    volumes:
+      # 사용자 정의 Nginx 설정 파일을 컨테이너 내부에 마운트합니다.
+      # A/B 테스트 라우팅 로직이 여기에 정의됩니다.
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro # 로컬 ./nginx/nginx.conf 파일을 컨테이너 내부로 읽기 전용 마운트
+      # A/B 테스트 로직에 쿠키 등이 필요하면 Nginx 설정에 따라 추가 설정 필요
+    depends_on:
+      # Nginx는 OpenWebUI V1/V2 서비스가 준비된 후에 시작되어야 합니다.
+      - open-webui_v1
+      - open-webui_v2
+    networks:
+      - webui_network
+    restart: unless-stopped
+
+  # ############################################
+  # OpenWebUI V1 - Web Interface for LLMs (Version A)
+  # ############################################
+  open-webui_v1:
+    # A 버전에 해당하는 OpenWebUI 이미지 태그 또는 빌드 설정
+    # image: ghcr.io/open-webui/open-webui:main # 예시: 최신 main 태그
+    image: ghcr.io/open-webui/open-webui:v0.6.6 # 예시: latest 태그 (사용하는 V1 이미지 지정)
+    container_name: open_webui_v1
+    # 이 서비스는 Nginx 프록시에서만 접근하므로 호스트 포트 노출은 필요 없습니다.
+    # ports: # 기존 "8080:8080" 매핑 제거
+    environment:
+      # OpenWebUI가 LiteLLM 프록시를 바라보도록 설정합니다.
+      # Docker 내부 네트워크에서는 서비스 이름(litellm)으로 접근합니다.
+      - OPENAI_API_BASE_URL=http://litellm:4000/ # LiteLLM 서비스 주소 (V1/V2 동일)
+      - OPENAI_API_KEY=dummy-key # LiteLLM이 자체 인증 처리 시 임의 값
+      # 필요에 따라 OpenWebUI V1의 특정 환경 변수 추가 가능
+    volumes:
+      # V1의 설정 및 데이터 저장을 위한 전용 볼륨 (권장)
+      - open_webui_v1_data:/app/backend/data
+    depends_on:
+      - litellm # LiteLLM이 먼저 시작되도록 의존성 설정
+    networks:
+      - webui_network
+    restart: unless-stopped
+
+  # ############################################
+  # OpenWebUI V2 - Web Interface for LLMs (Version B)
+  # ############################################
+  open-webui_v2:
+    # B 버전에 해당하는 OpenWebUI 이미지 태그 또는 빌드 설정
+    # image: ghcr.io/open-webui/open-webui:another-feature-tag # 예시: 다른 기능 태그
+    # 또는 로컬 Dockerfile로 빌드
+    # build:
+    #   context: ../path/to/your/openwebui/v2/code # V2 OpenWebUI 소스 코드 경로
+    #   dockerfile: Dockerfile # V2용 Dockerfile
+    image: ghcr.io/open-webui/open-webui:main # 예시: V2 이미지 태그 지정
+    container_name: open_webui_v2
+    # 이 서비스도 Nginx 프록시에서만 접근하므로 호스트 포트 노출은 필요 없습니다.
+    # ports: # 기존 "8080:8080" 매핑 제거
+    environment:
+      # LiteLLM 백엔드 주소 (V1과 동일)
+      - OPENAI_API_BASE_URL=http://litellm:4000/
+      - OPENAI_API_KEY=dummy-key
+      # 필요에 따라 OpenWebUI V2의 특정 환경 변수 추가 가능
+    volumes:
+      # V2의 설정 및 데이터 저장을 위한 전용 볼륨 (권장)
+      - open_webui_v2_data:/app/backend/data
+    depends_on:
+      - litellm # LiteLLM이 먼저 시작되도록 의존성 설정
+    networks:
+      - webui_network
+    restart: unless-stopped
+
+  # ############################################
+  # LiteLLM - LLM Proxy (OpenWebUI V1/V2의 공통 백엔드)
+  # ############################################
   litellm:
     image: ghcr.io/berriai/litellm:main-stable # 안정적인 최신 LiteLLM 이미지 사용
-    container_name: litellm_proxy
+    container_name: litellm_proxy # 이름 변경 (선택 사항)
+    # 이 서비스는 OpenWebUI 컨테이너들에서만 접근하므로 호스트 포트 매핑이 필수는 아닙니다.
+    # 필요에 따라 외부 접근용으로 남겨둘 수 있지만, A/B 테스트 아키텍처 상의 필수 요소는 아닙니다.
     ports:
-      - "4000:4000" # 호스트의 4000번 포트를 컨테이너의 4000번 포트로 매핑 (필요에 따라 변경 가능)
+      - "4000:4000" # 호스트의 4000번 포트를 컨테이너의 4000번 포트로 매핑 (외부에서 직접 접근 시)
     environment:
       # .env 파일 또는 직접 여기에 API 키를 설정하세요.
       # LiteLLM 설정 파일 (config.yaml) 내에서도 설정할 수 있습니다.
@@ -17,11 +92,9 @@ services:
       - AZURE_API_VERSION=${AZURE_API_VERSION}
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
       - LITELLM_SALT_KEY=${LITELLM_SALT_KEY}
-      - LITELLM_LICENSE=${LITELLM_LICENSE}
       - DATABASE_URL=${DATABASE_URL}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       # 추가 클라우드 서비스 또는 로컬 모델 API 키/주소 등
-      # - OLLAMA_API_BASE_URL=http://host.docker.internal:11434 # Docker 호스트에서 Ollama 실행 시 예시
     volumes:
       - ./litellm_config.yaml:/app/config.yaml # 호스트의 설정 파일을 컨테이너 내부로 마운트
       # - litellm_data:/app/data # 필요시 LiteLLM 데이터 볼륨 (예: 캐시)
@@ -33,32 +106,9 @@ services:
       - webui_network
     restart: unless-stopped
 
-  ############################################
-  # OpenWebUI - Web Interface for LLMs
-  ############################################
-  open-webui:
-    image: ghcr.io/open-webui/open-webui:main # 공식 OpenWebUI 이미지
-    container_name: open_webui
-    ports:
-      - "8080:8080" # 호스트의 8080 포트를 컨테이너의 8080 포트로 매핑 (기본값, 충돌 시 변경)
-    environment:
-      # OpenWebUI가 LiteLLM 프록시를 바라보도록 설정합니다.
-      # Docker 내부 네트워크에서는 서비스 이름(litellm)으로 접근합니다.
-      - OPENAI_API_BASE_URL=http://litellm:4000/ # LiteLLM 서비스 주소
-      - OPENAI_API_KEY=dummy-key # LiteLLM이 자체 인증을 처리하므로 여기서는 임의의 값 사용 가능 (LiteLLM 설정에 따라 필요 없을 수도 있음)
-      # 필요에 따라 OpenWebUI의 다른 환경 변수 추가 가능
-      # - ENABLE_SIGNUP=false # 사용자 가입 비활성화 예시
-    volumes:
-      - open_webui_data:/app/backend/data # OpenWebUI 설정 및 데이터 저장을 위한 볼륨
-    depends_on:
-      - litellm # LiteLLM이 먼저 시작되도록 의존성 설정
-    networks:
-      - webui_network
-    restart: unless-stopped
-
-  ############################################
-  # PostgreSQL Database (NEW)
-  ############################################
+  # ############################################
+  # PostgreSQL Database
+  # ############################################
   postgres:
     image: postgres:16 # PostgreSQL 버전 16 이미지 사용
     container_name: postgres_db
@@ -75,6 +125,9 @@ services:
       - webui_network
     restart: unless-stopped
 
+  # ############################################
+  # Prometheus Monitoring
+  # ############################################
   prometheus:
     image: prom/prometheus
     container_name: prometheus_monitor
@@ -88,6 +141,58 @@ services:
     networks:
       - webui_network
     restart: unless-stopped
+  # ############################################
+  # nginx 모니터링을 위한 exporter
+  # ############################################
+  nginx_exporter:
+    image: nginx/nginx-prometheus-exporter:latest
+    container_name: nginx_exporter
+    command:
+      - -nginx.scrape-uri=http://nginx_proxy/nginx_status
+    ports:
+      - "9113:9113"
+    depends_on:
+      - nginx_proxy
+    networks:
+      - webui_network
+    restart: unless-stopped
+  # ############################################
+  # NginX 테스트 상황 시각화를 위한 Gafana, Loki, Promtail
+  # ############################################    
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - webui_network
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:2.9.2
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - webui_network
+
+  promtail:
+    image: grafana/promtail:2.9.2
+    container_name: promtail
+    volumes:
+      # Nginx 로그 볼륨을 Promtail 컨테이너의 동일 경로에 마운트
+      - nginx_logs:/var/log/nginx
+      - ./promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    networks:
+      - webui_network
+    depends_on:
+      - loki # Promtail은 Loki가 시작된 후 시작되어야 함
 
 networks:
   webui_network:
@@ -95,7 +200,10 @@ networks:
 
 volumes:
   postgres_data: # PostgreSQL 데이터 볼륨
-  open_webui_data: # OpenWebUI 데이터를 영속적으로 저장할 명명된 볼륨
+  open_webui_v1_data: # OpenWebUI V1 데이터를 영속적으로 저장할 명명된 볼륨 (새로 추가)
+  open_webui_v2_data: # OpenWebUI V2 데이터를 영속적으로 저장할 명명된 볼륨 (새로 추가)
   prometheus_data: # Prometheus 데이터 볼륨
+  grafana_data:
+  nginx_logs: # <-- Nginx 로그를 위한 새로운 볼륨 정의
 
   # litellm_data: # LiteLLM 데이터용 볼륨 (필요시 주석 해제)

--- a/docker-related/docker-compose.yml
+++ b/docker-related/docker-compose.yml
@@ -208,6 +208,6 @@ volumes:
   open_webui_v2_data: # OpenWebUI V2 데이터를 영속적으로 저장할 명명된 볼륨 (새로 추가)
   prometheus_data: # Prometheus 데이터 볼륨
   # grafana_data:
-  # nginx_logs: # <-- Nginx 로그를 위한 새로운 볼륨 정의
+  nginx_logs: # <-- Nginx 로그를 위한 새로운 볼륨 정의
 
   # litellm_data: # LiteLLM 데이터용 볼륨 (필요시 주석 해제)

--- a/docker-related/nginx/nginx.conf
+++ b/docker-related/nginx/nginx.conf
@@ -1,0 +1,62 @@
+# docker-related/nginx/nginx.conf
+
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # --- Upstream Servers (OpenWebUI V1 and V2) ---
+    upstream openwebui_v1_servers {
+        server open-webui_v1:8080;
+    }
+
+    upstream openwebui_v2_servers {
+        server open-webui_v2:8080;
+    }
+
+    # --- A/B Test Mapping ---
+    split_clients "$remote_addr" $ab_test_group {
+        80% openwebui_v1_servers;
+        * openwebui_v2_servers;
+    }
+
+    # A/B 테스트 결과를 로그에 포함시키는 새로운 로그 포맷 정의
+    log_format ab_test_loki_format '$remote_addr - $remote_user [$time_local] "$request" '
+                                   '$status $body_bytes_sent "$http_referer" '
+                                   '"$http_user_agent" "$http_x_forwarded_for" '
+                                   '"$ab_test_group"'; # <-- $ab_test_group 변수 추가
+
+    server {
+        # 새로운 로그 포맷을 사용하여 access_log 설정
+        access_log /var/log/nginx/access.log ab_test_loki_format;
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_pass http://$ab_test_group;
+
+            # A/B 테스트 결과를 클라이언트 쿠키에 설정 (선택 사항)
+            add_header Set-Cookie "ab_test=$ab_test_group; path=/";
+        }
+
+        location /nginx_status {
+            stub_status on;
+            allow 127.0.0.1;
+            allow 172.18.0.0/16; # Docker 브릿지 네트워크 대역 (docker inspect로 확인 가능)
+            deny all;
+        }
+    }
+}

--- a/docker-related/prometheus_config/prometheus.yml
+++ b/docker-related/prometheus_config/prometheus.yml
@@ -9,7 +9,9 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090'] # Prometheus 웹 UI/API 포트
-
+  - job_name: 'nginx'
+    static_configs:
+      - targets: ['nginx_exporter:9113']
   # 나중에 LiteLLM 등 다른 서비스에서 메트릭을 제공하면 여기에 추가
   # 예시: LiteLLM이 8000번 포트에서 메트릭을 제공한다고 가정
   # - job_name: 'litellm'

--- a/docker-related/promtail-config.yml
+++ b/docker-related/promtail-config.yml
@@ -9,23 +9,34 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: nginx-logs
-    # Nginx 로그 파일이 있는 경로 (docker-compose에서 마운트한 경로)
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: nginx
-          container_name: nginx_ab_router # 컨테이너 이름 레이블 추가 (Grafana 필터링에 유용)
-          __path__: /var/log/nginx/access.log # Nginx 로그 파일 경로
+  - job_name: docker-nginx-logs
+    # Docker 데몬에서 로그를 직접 가져오는 설정입니다.
+    # docker_sd_configs는 리스트 형태여야 합니다.
+    docker_sd_configs:
+      # 이 하이픈(-)이 리스트의 첫 번째 항목을 나타냅니다.
+      - host: unix:///var/run/docker.sock # Docker 소켓 경로 (환경에 맞게 수정)
+
+    # 어떤 컨테이너의 로그를 가져올지 필터링하고 레이블을 추가합니다.
+    relabel_configs:
+      # ... (이전과 동일) ...
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/nginx_ab_router'
+        action: keep
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container_name
+        replacement: '$1'
+      - source_labels: ['__meta_docker_image']
+        target_label: image_name
+      - source_labels: ['__meta_docker_container_id']
+        target_label: container_id
+        regex: '(.{12}).*'
+
+    # 로그 라인을 파싱하고 레이블을 추출하는 파이프라인
     pipeline_stages:
-      # Nginx의 ab_test_loki_format에 맞는 Grok 패턴
-      # 패턴은 실제 로그 라인과 정확히 일치해야 합니다.
+      # ... (이전과 동일) ...
       - grok:
-          # 예시 패턴: IP - user [시간] "요청" 상태 본문크기 "Referer" "UserAgent" "XFF" "AB_VERSION"
-          # 각 필드에 이름을 부여하여 추출합니다.
           pattern: '%{IPORHOST:remote_addr} - %{WORD:remote_user} \[%{HTTPDATE:time_local}\] \"(?:%{WORD:method})? %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version})?\" %{NUMBER:status} %{NUMBER:body_bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" \"%{DATA:http_x_forwarded_for}\" \"%{DATA:ab_version}\"'
-      # Grok에서 추출한 필드를 Loki 레이블로 변환
       - labels:
-          status: # HTTP 상태 코드 레이블
-          ab_version: # AB 테스트 버전 레이블 (예: openwebui_v1_servers, openwebui_v2_servers)
+          status:
+          ab_version:

--- a/docker-related/promtail-config.yml
+++ b/docker-related/promtail-config.yml
@@ -1,3 +1,5 @@
+# promtail-config.yml 파일 수정 내용
+
 server:
   http_listen_port: 9080
   grpc_listen_port: 0
@@ -9,34 +11,49 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: docker-nginx-logs
-    # Docker 데몬에서 로그를 직접 가져오는 설정입니다.
-    # docker_sd_configs는 리스트 형태여야 합니다.
-    docker_sd_configs:
-      # 이 하이픈(-)이 리스트의 첫 번째 항목을 나타냅니다.
-      - host: unix:///var/run/docker.sock # Docker 소켓 경로 (환경에 맞게 수정)
+  - job_name: nginx-file-logs # job_name 변경 (선택 사항)
 
-    # 어떤 컨테이너의 로그를 가져올지 필터링하고 레이블을 추가합니다.
+    # Docker 데몬에서 로그를 직접 가져오는 설정 (이 부분 삭제하거나 주석 처리)
+    # docker_sd_configs:
+    #   - host: unix:///var/run/docker.sock
+
+    # 파일 기반 로그 수집 설정 추가
+    static_configs:
+      # 리스트 형태로 수집할 파일 경로 지정
+      - targets:
+          - localhost # 호스트는 localhost 또는 127.0.0.1 로 설정 (컨테이너 자신의 파일 시스템)
+        labels:
+          job: nginx-access-logs # Loki에서 사용할 job 레이블
+          __path__: /var/log/nginx/*log # Promtail 컨테이너 내부에서 로그 파일 경로 지정 (와일드카드 사용 가능)
+
+    # 레이블 재설정 (필요에 따라 수정)
+    # 파일 기반 수집에서는 __meta_docker_* 레이블을 직접 사용할 수 없습니다.
+    # 필요하다면 __path__ 등의 다른 메타 레이블을 기반으로 재설정하거나,
+    # pipeline_stages에서 추출한 정보로 레이블을 추가해야 합니다.
+    # 여기서는 Grok 파싱 결과를 레이블로 사용하는 방식을 유지합니다.
     relabel_configs:
-      # ... (이전과 동일) ...
-      - source_labels: ['__meta_docker_container_name']
-        regex: '/nginx_ab_router'
-        action: keep
-      - source_labels: ['__meta_docker_container_name']
-        regex: '/(.*)'
-        target_label: container_name
-        replacement: '$1'
-      - source_labels: ['__meta_docker_image']
-        target_label: image_name
-      - source_labels: ['__meta_docker_container_id']
-        target_label: container_id
-        regex: '(.{12}).*'
+      # __meta_docker_* 관련 relabeling은 이 방식에서 작동하지 않습니다.
+      # 필요하다면 __path__ 등을 사용하여 relabeling 규칙을 재작성해야 합니다.
+      # 예: 파일 경로에서 컨테이너 이름을 추출하는 relabel (필요하다면)
+      # - source_labels: ['__path__']
+      #   regex: '/var/log/nginx/(.*)/.*' # 예시: /var/log/nginx/컨테이너명/access.log 와 같은 구조일 경우
+      #   target_label: container_name
 
-    # 로그 라인을 파싱하고 레이블을 추출하는 파이프라인
+      # job 레이블을 static_configs에서 정의한 것으로 사용
+      - source_labels: ['__address__']
+        regex: '.*'
+        target_label: __host__
+        replacement: '{{ .Target }}' # target 값 (localhost)으로 host 레이블 설정
+
+    # 로그 라인을 파싱하고 레이블을 추출하는 파이프라인 (이 부분은 동일하게 유지)
+    # Grok 스테이지가 이 방식에서는 정상 작동하기를 기대합니다.
     pipeline_stages:
-      # ... (이전과 동일) ...
       - grok:
           pattern: '%{IPORHOST:remote_addr} - %{WORD:remote_user} \[%{HTTPDATE:time_local}\] \"(?:%{WORD:method})? %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version})?\" %{NUMBER:status} %{NUMBER:body_bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" \"%{DATA:http_x_forwarded_for}\" \"%{DATA:ab_version}\"'
+      # Grok에서 추출한 필드를 레이블로 추가
       - labels:
           status:
           ab_version:
+          # Grok 패턴에서 추출한 다른 필드도 필요하면 여기에 추가 (예: method, request 등)
+          # method:
+          # request:

--- a/docker-related/promtail-config.yml
+++ b/docker-related/promtail-config.yml
@@ -45,15 +45,15 @@ scrape_configs:
         target_label: __host__
         replacement: '{{ .Target }}' # target 값 (localhost)으로 host 레이블 설정
 
-    # 로그 라인을 파싱하고 레이블을 추출하는 파이프라인 (이 부분은 동일하게 유지)
-    # Grok 스테이지가 이 방식에서는 정상 작동하기를 기대합니다.
-    pipeline_stages:
-      - grok:
-          pattern: '%{IPORHOST:remote_addr} - %{WORD:remote_user} \[%{HTTPDATE:time_local}\] \"(?:%{WORD:method})? %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version})?\" %{NUMBER:status} %{NUMBER:body_bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" \"%{DATA:http_x_forwarded_for}\" \"%{DATA:ab_version}\"'
-      # Grok에서 추출한 필드를 레이블로 추가
-      - labels:
-          status:
-          ab_version:
-          # Grok 패턴에서 추출한 다른 필드도 필요하면 여기에 추가 (예: method, request 등)
-          # method:
-          # request:
+    # # 로그 라인을 파싱하고 레이블을 추출하는 파이프라인 (이 부분은 동일하게 유지)
+    # # Grok 스테이지가 이 방식에서는 정상 작동하기를 기대합니다.
+    # pipeline_stages:
+    #   - grok:
+    #       pattern: '%{IPORHOST:remote_addr} - %{WORD:remote_user} \[%{HTTPDATE:time_local}\] \"(?:%{WORD:method})? %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version})?\" %{NUMBER:status} %{NUMBER:body_bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" \"%{DATA:http_x_forwarded_for}\" \"%{DATA:ab_version}\"'
+    #   # Grok에서 추출한 필드를 레이블로 추가
+    #   - labels:
+    #       status:
+    #       ab_version:
+    #       # Grok 패턴에서 추출한 다른 필드도 필요하면 여기에 추가 (예: method, request 등)
+    #       # method:
+    #       # request:

--- a/docker-related/promtail-config.yml
+++ b/docker-related/promtail-config.yml
@@ -1,0 +1,31 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: nginx-logs
+    # Nginx 로그 파일이 있는 경로 (docker-compose에서 마운트한 경로)
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: nginx
+          container_name: nginx_ab_router # 컨테이너 이름 레이블 추가 (Grafana 필터링에 유용)
+          __path__: /var/log/nginx/access.log # Nginx 로그 파일 경로
+    pipeline_stages:
+      # Nginx의 ab_test_loki_format에 맞는 Grok 패턴
+      # 패턴은 실제 로그 라인과 정확히 일치해야 합니다.
+      - grok:
+          # 예시 패턴: IP - user [시간] "요청" 상태 본문크기 "Referer" "UserAgent" "XFF" "AB_VERSION"
+          # 각 필드에 이름을 부여하여 추출합니다.
+          pattern: '%{IPORHOST:remote_addr} - %{WORD:remote_user} \[%{HTTPDATE:time_local}\] \"(?:%{WORD:method})? %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version})?\" %{NUMBER:status} %{NUMBER:body_bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" \"%{DATA:http_x_forwarded_for}\" \"%{DATA:ab_version}\"'
+      # Grok에서 추출한 필드를 Loki 레이블로 변환
+      - labels:
+          status: # HTTP 상태 코드 레이블
+          ab_version: # AB 테스트 버전 레이블 (예: openwebui_v1_servers, openwebui_v2_servers)


### PR DESCRIPTION
- AB TEST를 위한 접근 분배를 위하여 nginx 도입
- Gafana, promtail 등을 통해 명확한 모니터링을 시도했지만, docker desktop for windows의 오류로 실험이 불가하였기에 비활성화하여 push
- Open Webui를 사용하는 두 가지 컨테이너를 활용하여 A, B 테스트를 할 수 있도록 코드를 구성함